### PR TITLE
Add Cache-Control header to Cloudfront.

### DIFF
--- a/sitemap-template.php
+++ b/sitemap-template.php
@@ -32,6 +32,8 @@
 */
 header( 'HTTP/1.0 200 OK' );
 header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ), true );
+header( 'Cache-Control: public, must-revalidate, proxy-revalidate, max-age=0' );
+
 echo '<?xml version="1.0" encoding="'.get_option( 'blog_charset' ).'"?'.'>'; 
 ?>
 


### PR DESCRIPTION
In order to avoid cloudfront cache, but without explicitly telling `no-cache`, avoiding full sitemap.xml transfer in every request, it adds the following header.
```
Cache-Control: public, must-revalidate, proxy-revalidate, max-age=0
```